### PR TITLE
Fix for testthat 3.3.0

### DIFF
--- a/tests/testthat/test-zeros.R
+++ b/tests/testthat/test-zeros.R
@@ -1,11 +1,11 @@
 context("zeros")
 
 test_that("zero is zero", {
-  expect_that(is_zero(0), is_true())
-  expect_that(is_zero(0.0000000001), is_false())
-  expect_that(is_zero(111), is_false())
-  expect_that(is_zero(-111), is_false())
-  expect_that(is_zero(TRUE), is_false())
-  expect_that(all(is_zero(c(0, 0))), is_true())
-  expect_that(is_zero("111"), is_false())
+  expect_true(is_zero(0))
+  expect_false(is_zero(0.0000000001))
+  expect_false(is_zero(111))
+  expect_false(is_zero(-111))
+  expect_false(is_zero(TRUE))
+  expect_true(all(is_zero(c(0, 0))))
+  expect_false(is_zero("111"))
 })


### PR DESCRIPTION
`is_true()`, `is_false()`, and `is_null()` have been removed (after several years of deprecation) because they conflict with functions defined elsewhere in the tidyverse. I've updated your code to use the modern equivalent(s).